### PR TITLE
updated to work with captagent-latest

### DIFF
--- a/captagent/captagent.xml
+++ b/captagent/captagent.xml
@@ -20,7 +20,7 @@
     <configuration name="modules.conf" description="Modules">
         <modules>
             <load module="database_hash" register="local"/>
-            <load module="transport_json" register="local"/>
+            <load module="output_json" register="local"/>
             <load module="protocol_sip" register="local"/>
             <load module="protocol_rtcp" register="local"/>                                          
             <load module="socket_pcap" register="local"/>

--- a/captagent/output_json.xml
+++ b/captagent/output_json.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <document type="captagent_module/xml">
-    <module name="transport_json" description="JSON Protocol" serial="2014010403">
+    <module name="output_json" description="JSON Protocol" serial="2014010403">
     <profile name="jsonsocketsip" description="Transport JSON" enable="true" serial="2014010403">
         <settings>
         <param name="capture-version" value="1"/>


### PR DESCRIPTION
It seems the send_json function is registered by the "output_json" module, even if it is located in transport/json  and should be named transport_json.

This allows the capture plans to be loaded successfully on first launch.